### PR TITLE
Fixes, minor type corrections, more explicit parentheticals.

### DIFF
--- a/RISCV_Emulator.cc
+++ b/RISCV_Emulator.cc
@@ -126,9 +126,10 @@ Elf32_Shdr *search_shdr(std::vector<uint8_t> &program, int type) {
       return shdr;
     }
   }
+  return NULL;
 }
 
-void extend_mem_size(std::vector<uint8_t> &memory, int new_size) {
+void extend_mem_size(std::vector<uint8_t> &memory, size_t new_size) {
   if (memory.size() < new_size) {
     new_size = (new_size + kUnitSize - 1) / kUnitSize * kUnitSize;
     memory.resize(new_size);
@@ -154,7 +155,7 @@ void loadElfFile(std::vector<uint8_t> &program, memory_wrapper &memory) {
                   << " from 0x" << static_cast<int>(phdr->p_offset) << std::dec
                   << ", size " << static_cast<int>(phdr->p_filesz) << ". ";
 
-        for (int i = 0; i < phdr->p_filesz; i++) {
+        for (Elf32_Word i = 0; i < phdr->p_filesz; i++) {
           memory[phdr->p_vaddr + i] = program[phdr->p_offset + i];
         }
         std::cerr << "Loaded" << std::endl;

--- a/RISCV_Emulator.cc
+++ b/RISCV_Emulator.cc
@@ -36,7 +36,7 @@ std::vector<uint8_t> readFile(std::string filename)
 
   // read the data:
   std::vector<uint8_t> fileData;
-  fileData.resize(size);
+  fileData.resize((unsigned int)size);
   file.read(reinterpret_cast<char *>(fileData.data()), size);
   return fileData;
 }
@@ -113,7 +113,7 @@ Elf32_Shdr *search_shdr(std::vector<uint8_t> &program, std::string name) {
   return NULL;
 }
 
-Elf32_Shdr *search_shdr(std::vector<uint8_t> &program, int type) {
+Elf32_Shdr *search_shdr(std::vector<uint8_t> &program, Elf32_Word type) {
   Elf32_Ehdr *ehdr = get_ehdr(program);
 
   // Find the last section header that has the name information.

--- a/RISCV_cpu.cc
+++ b/RISCV_cpu.cc
@@ -177,7 +177,7 @@ int RiscvCpu::run_cpu(uint32_t start_pc, bool verbose) {
         break;
       case INST_SRA:
         reg[rd] = static_cast<int32_t>(reg[rs1]) >> (reg[rs2] & 0x1F);
-        check((reg[rs1] & 0x1F <= 0) || (reg[rs1] & 0x80000000 == 0));
+        check(((reg[rs1] & 0x1F) <= 0) || ((reg[rs1] & 0x80000000) == 0));
         break;
       case INST_SLT:
         reg[rd] = (static_cast<int32_t>(reg[rs1]) < static_cast<int32_t>(reg[rs2])) ? 1 : 0;
@@ -199,15 +199,15 @@ int RiscvCpu::run_cpu(uint32_t start_pc, bool verbose) {
         break;
       case INST_SLLI:
         reg[rd] = reg[rs1] << shamt;
-        check(shamt >> 5 & 1 == 0);
+        check((shamt >> 5 & 1) == 0);
         break;
       case INST_SRLI:
         reg[rd] = reg[rs1] >> shamt;
-        check(shamt >> 5 & 1 == 0);
+        check((shamt >> 5 & 1) == 0);
         break;
       case INST_SRAI:
         reg[rd] = static_cast<int32_t>(reg[rs1]) >> shamt;
-        check(shamt >> 5 & 1 == 0);
+        check((shamt >> 5 & 1) == 0);
         break;
       case INST_SLTI:
         reg[rd] = static_cast<int32_t>(reg[rs1]) < imm12 ? 1 : 0;

--- a/load_assembler_test.cc
+++ b/load_assembler_test.cc
@@ -592,7 +592,7 @@ bool test_i_type(bool verbose = false) {
         }
           break;
         case TEST_FENCEI:
-          rd = rs1 = imm12 = 0;
+          rd = rs1 = 0; imm12 = 0;
           cmd = asm_fencei();
           break;
         default:
@@ -716,7 +716,7 @@ bool test_j_type(bool verbose = false) {
     }
     uint8_t opcode = base & 0b01111111;
 
-    for (int i = 0; i < TEST_NUM & !error; i++) {
+    for (int i = 0; i < TEST_NUM && !error; i++) {
       uint32_t cmd;
       uint8_t rd = rnd() % 32;
       int32_t imm21 = (rnd() % (1 << 21)) - (1 << 20);

--- a/memory_wrapper.h
+++ b/memory_wrapper.h
@@ -20,7 +20,7 @@ class memory_wrapper {
   static constexpr int kEntryBits = kTotalBits - kOffsetBits;
   static constexpr int kEntryMask = 0x0FFF;
   static constexpr int kMapEntry = 1 << kEntryBits;
-  static constexpr size_t kMaxEntry = 1l << kTotalBits;
+  static constexpr size_t kMaxEntry = ((1ull << 32) - 1);
 public:
   uint8_t &operator[]( size_t i);
   memory_wrapper_iterator begin();

--- a/memory_wrapper.h
+++ b/memory_wrapper.h
@@ -20,7 +20,7 @@ class memory_wrapper {
   static constexpr int kEntryBits = kTotalBits - kOffsetBits;
   static constexpr int kEntryMask = 0x0FFF;
   static constexpr int kMapEntry = 1 << kEntryBits;
-  static constexpr size_t kMaxEntry = ((1ull << 32) - 1);
+  static constexpr size_t kMaxEntry = ((1ull << kTotalBits) - 1);
 public:
   uint8_t &operator[]( size_t i);
   memory_wrapper_iterator begin();


### PR DESCRIPTION
This has a few fixes:
kMaxEntry did not work on 32-bit systems. Shifting a size_t < 32 bits resulted in null. The fix applied works but it could also be converted to a uint64_t, if you need a value > 32 bits.
load_assembler_test.cc had a logical "&" when a conditional was intended.
search_shdr was missing a return value.

The other changes are minor updates to fix types and make a few lines less ambiguous.