### PR TITLE
Fixes and disambiguation.

### DIFF
--- a/Mmu.cpp
+++ b/Mmu.cpp
@@ -102,7 +102,7 @@ uint64_t Mmu::VirtualToPhysical64(uint64_t virtual_address, uint64_t satp,
   uint64_t ppn2 = pte.GetPpn2();
   uint64_t ppn1 = (level > 1) ? vpn[1] : pte.GetPpn1();
   uint32_t ppn0 = (level > 0) ? vpn[0] : pte.GetPpn0();
-  physical_address = (ppn2 << 30) | (ppn1 << 21) | (ppn0 << 12) | offset;
+  physical_address = (ppn2 << 30) | (ppn1 << 21) | ((uint64_t)ppn0 << 12) | offset;
 
   constexpr uint64_t kMask56Bit = 0x00FFFFFFFFFFFFFF;
   uint64_t physical_address_64bit = static_cast<uint64_t >(physical_address & kMask56Bit);
@@ -172,7 +172,7 @@ uint64_t Mmu::VirtualToPhysical32(uint64_t virtual_address, uint64_t satp,
   // TODO: Add PMP check. (Page 70 of RISC-V Privileged Architectures Manual Vol. II.)
   uint64_t ppn1 = pte.GetPpn1();
   uint32_t ppn0 = (level == 1) ? vpn0 : pte.GetPpn0();
-  physical_address = (ppn1 << 22) | (ppn0 << 12) | offset;
+  physical_address = (ppn1 << 22) | ((uint64_t)ppn0 << 12) | offset;
 
   uint64_t physical_address_64bit = static_cast<uint64_t >(physical_address &
                                                            0xFFFFFFFF);

--- a/Mmu.h
+++ b/Mmu.h
@@ -26,7 +26,7 @@ class Mmu {
   uint64_t VirtualToPhysical64(uint64_t virtual_address, uint64_t satp, bool write_access = false);
 
   std::shared_ptr<MemoryWrapper> memory_;
-  int mxl_;
+  int mxl_ = 0;
   bool page_fault_ = false;
   uint64_t faulting_address_ = 0;
   PrivilegeMode privilege_ = PrivilegeMode::MACHINE_MODE;

--- a/RISCV_cpu.cc
+++ b/RISCV_cpu.cc
@@ -164,7 +164,7 @@ void RiscvCpu::Trap(int cause, bool interrupt) {
   // Currently supported interrupts: Supervisor Software Interrupt (1), Machine Timer Intetrupt (7)
   assert((interrupt && (cause == MACHINE_TIMER_INTERRUPT || cause == SUPERVISOR_SOFTWARRE_INTERRUPT ||
                         cause == SUPERVISOR_EXTERNAL_INTERRUPT)) ||
-             (!interrupt &
+             ((!interrupt) &
          (cause == INSTRUCTION_PAGE_FAULT || cause == LOAD_PAGE_FAULT || cause == STORE_PAGE_FAULT ||
           cause == ECALL_UMODE || cause == ECALL_SMODE || cause == ECALL_MMODE)));
   // Check the Machine Level Enable.
@@ -718,7 +718,7 @@ void RiscvCpu::MultInstruction(uint32_t instruction, uint32_t rd, uint32_t rs1, 
         temp64 = -1;
       } else if (static_cast<int64_t>(reg_[rs2]) == -1 && reg_[rs1] == (1lu << 31)) {
         // Overflow check.
-        temp64 = 1 << 31;
+        temp64 = (uint64_t)1 << 31;
       } else {
         temp64 = static_cast<int64_t>(SignExtend(reg_[rs1], 32)) / static_cast<int64_t>(SignExtend(reg_[rs2], 32));
       }

--- a/bit_tools.h
+++ b/bit_tools.h
@@ -15,9 +15,9 @@ constexpr T GenMask(int size, int shift) {
 template<typename T>
 T SetBit(T data, int value, int pos) {
   if (value) {
-    return data | (1 << pos);
+    return data | ((T)1 << pos);
   } else {
-    return data & ~(1 << pos);
+    return data & ~((T)1 << pos);
   }
 }
 

--- a/memory_wrapper.cpp
+++ b/memory_wrapper.cpp
@@ -8,6 +8,7 @@
 namespace RISCV_EMULATOR {
 
 MemoryWrapper::MemoryWrapper() {
+    assigned_ = {}; // Default value
   for (auto &a: assigned_) {
     a = false;
   }
@@ -33,7 +34,7 @@ void MemoryWrapper::WriteByte(size_t i, uint8_t data) {
   uint64_t write_data = data;
   int byte_offset = i & 0b11;
   write_data = (original_data & mask[byte_offset]) | (write_data << byte_offset * 8);
-  Write32(dram_address, write_data);
+  Write32(dram_address, (uint32_t)write_data);
 }
 
 const uint16_t MemoryWrapper::Read16(size_t i) const {
@@ -54,14 +55,14 @@ void MemoryWrapper::Write16(size_t i, uint16_t data) {
   uint64_t dram_address = (i >> kWordBits) << kWordBits;
   uint32_t original_data = Read32(dram_address);
   int short_word_offset = (i >> 1) & 1;
-  uint32_t write_data = (original_data & mask[short_word_offset]) | (data << short_word_offset * 16);
+  uint32_t write_data = (original_data & (uint32_t)mask[short_word_offset]) | (data << short_word_offset * 16);
   Write32(dram_address, write_data);
 }
 
 const uint32_t MemoryWrapper::Read32(size_t i) const {
   assert((i & 0b11) == 0);
   int entry = (i >> kOffsetBits) & kEntryMask;
-  uint64_t read_data = 0;
+  uint32_t read_data = 0;
   if (CheckRange(entry)) {
     int offset = i & kOffsetMask;
     int word_offset = offset >> kWordBits;

--- a/memory_wrapper.h
+++ b/memory_wrapper.h
@@ -5,10 +5,10 @@
 #ifndef MEMORY_WRAPPER_H
 #define MEMORY_WRAPPER_H
 
-
 #include <vector>
 #include <cstdint>
 #include <array>
+#include <stdexcept>
 
 namespace RISCV_EMULATOR {
 

--- a/pte.cpp
+++ b/pte.cpp
@@ -196,7 +196,7 @@ void Pte64::SetPpn(uint64_t ppn) {
 }
 
 void Pte64::SetRsw(uint32_t rsw) {
-  pte_ = (pte_ & ~GenMask<uint64_t>(2, 8)) | (rsw << 8);
+  pte_ = (pte_ & ~GenMask<uint64_t>(2, 8)) | ((uint64_t)rsw << 8);
 }
 
 void Pte64::SetD(int value) {

--- a/system_call_emulator.cpp
+++ b/system_call_emulator.cpp
@@ -161,7 +161,7 @@ SystemCallEmulation(std::shared_ptr<MemoryWrapper> memory, uint64_t *reg,
     std::cerr << std::endl;
     ssize_t return_value = CIO_write(reg[A0], buffer, length);
     reg[A0] = return_value;
-    delete buffer;
+    delete[] buffer;
   } else if (reg[A7] == 214) {
     // BRK.
     if (debug) {
@@ -187,7 +187,7 @@ SystemCallEmulation(std::shared_ptr<MemoryWrapper> memory, uint64_t *reg,
     for (int i = 0; i < length; i++) {
       mem.WriteByte(reg[A1] + i, buffer[i]);
     }
-    delete buffer;
+    delete[] buffer;
   } else if (reg[A7] == 80) {
     // FSTAT.
     struct Riscv32NewlibStat guest_stat;
@@ -281,7 +281,7 @@ SystemCallEmulation(std::shared_ptr<MemoryWrapper> memory, uint64_t *reg,
       }
       return_value = CIO_open(buffer, flag, reg[A2]);
       if (return_value >= 0) openHandles++;
-      delete buffer;
+      delete[] buffer;
     }
     reg[A0] = return_value;
   } else if (reg[A7] == 62) {


### PR DESCRIPTION
Fixed incorrect non-array deletes in system_call_emulator.cpp.
Added initial value for mxl_ and assigned_.
Added missing stdexcept to memory_wrapper.h.
Added some casting/disambiguation.